### PR TITLE
嵌套TableView在iOS11以下支持自动布局

### DIFF
--- a/Pbind/Classes/View/PBCollectionView.m
+++ b/Pbind/Classes/View/PBCollectionView.m
@@ -16,6 +16,8 @@
 #import "PBSectionMapper.h"
 #import "UIView+Pbind.h"
 #import "PBCollectionViewFlowLayout.h"
+#import "PBTableView.h"
+
 @interface PBCollectionView () <PBCollectionViewFlowLayoutDelegate>
 
 @end
@@ -270,6 +272,19 @@
         return;
     }
     
+    // Check if super cell is hidden
+    UITableViewCell *superCell = [self superviewWithClass:[UITableViewCell class]];
+    if (superCell != nil) {
+        PBTableView *superTableView = [superCell superviewWithClass:[PBTableView class]];
+        NSIndexPath *indexPath = [superTableView indexPathForCell:superCell];
+        if (indexPath != nil) {
+            PBRowMapper *row = [superTableView.rowDataSource rowAtIndexPath:indexPath];
+            if (row.hidden) {
+                return;
+            }
+        }
+    }
+    
     CGSize size = self.collectionViewLayout.collectionViewContentSize;
     if (CGSizeEqualToSize(size, CGSizeZero)) {
         return;
@@ -297,10 +312,12 @@
 
 - (void)setAutoItemSizing:(BOOL)autoItemSizing {
     _autoItemSizing = autoItemSizing;
-    if (autoItemSizing) {
-        _flowLayout.estimatedItemSize = CGSizeMake(1.f, 1.f);
-    } else {
-        _flowLayout.estimatedItemSize = CGSizeZero;
+    if (@available(iOS 11, *)) {
+        if (autoItemSizing) {
+            _flowLayout.estimatedItemSize = CGSizeMake(1.f, 1.f);
+        } else {
+            _flowLayout.estimatedItemSize = CGSizeZero;
+        }
     }
 }
 

--- a/Pbind/Classes/View/PBRowDataSource.m
+++ b/Pbind/Classes/View/PBRowDataSource.m
@@ -302,6 +302,10 @@ static const CGFloat kUITableViewRowAnimationDuration = .25f;
     if (rowSource != nil) {
         _row = [PBRowMapper mapperWithDictionary:rowSource owner:self.owner];
     }
+    if (_row == nil) {
+        return;
+    }
+    
     if ([self.owner conformsToProtocol:@protocol(PBDataFetching)]) {
         [(id)self.owner setDataUpdated:YES];
     }

--- a/Pbind/Classes/View/PBRowDataSource.m
+++ b/Pbind/Classes/View/PBRowDataSource.m
@@ -989,6 +989,10 @@ static const CGFloat kUITableViewRowAnimationDuration = .25f;
 }
 
 - (UICollectionViewCell *)collectionView:(PBCollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    return [self _collectionView:collectionView cellForItemAtIndexPath:indexPath reusing:YES];
+}
+
+- (UICollectionViewCell *)_collectionView:(PBCollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath reusing:(BOOL)reusing {
     UICollectionViewCell *cell = nil;
     if ([self.receiver respondsToSelector:_cmd]) {
         cell = [self.receiver collectionView:collectionView cellForItemAtIndexPath:indexPath];
@@ -1003,27 +1007,30 @@ static const CGFloat kUITableViewRowAnimationDuration = .25f;
     [self updateRowMapper:item forRowAtIndexPath:indexPath inView:collectionView withData:data];
     
     // Lazy register reusable cell
-    NSString *identifier = item.id;
-    BOOL needsRegister = NO;
-    if (collectionView.registeredCellIdentifiers == nil) {
-        collectionView.registeredCellIdentifiers = [[NSMutableArray alloc] init];
-        needsRegister = YES;
-    } else {
-        needsRegister = ![collectionView.registeredCellIdentifiers containsObject:identifier];
-    }
-    if (needsRegister) {
-        UINib *nib = PBNib(item.nib);
-        if (nib != nil) {
-            [collectionView registerNib:nib forCellWithReuseIdentifier:identifier];
+    if (reusing) {
+        NSString *identifier = item.id;
+        BOOL needsRegister = NO;
+        if (collectionView.registeredCellIdentifiers == nil) {
+            collectionView.registeredCellIdentifiers = [[NSMutableArray alloc] init];
+            needsRegister = YES;
         } else {
-            [collectionView registerClass:item.viewClass forCellWithReuseIdentifier:identifier];
+            needsRegister = ![collectionView.registeredCellIdentifiers containsObject:identifier];
         }
-        [collectionView.registeredCellIdentifiers addObject:identifier];
+        if (needsRegister) {
+            UINib *nib = PBNib(item.nib);
+            if (nib != nil) {
+                [collectionView registerNib:nib forCellWithReuseIdentifier:identifier];
+            } else {
+                [collectionView registerClass:item.viewClass forCellWithReuseIdentifier:identifier];
+            }
+            [collectionView.registeredCellIdentifiers addObject:identifier];
+        }
+        
+        // Dequeue reusable cell
+        cell = [collectionView dequeueReusableCellWithReuseIdentifier:item.id forIndexPath:indexPath];
+    } else {
+        cell = [item createView];
     }
-    
-    // Dequeue reusable cell
-    cell = [collectionView dequeueReusableCellWithReuseIdentifier:item.id forIndexPath:indexPath];
-    cell.indexPath = indexPath;
     
     // Auto size
     if ([item isAutoWidth]) {
@@ -1051,6 +1058,13 @@ static const CGFloat kUITableViewRowAnimationDuration = .25f;
         }
     }
     
+    [self _updateCell:cell forIndexPath:indexPath withData:data item:item context:collectionView];
+    return cell;
+}
+
+- (void)_updateCell:(UICollectionViewCell *)cell forIndexPath:(NSIndexPath *)indexPath withData:(id)data item:(PBRowMapper *)item context:(UIView *)context {
+    cell.indexPath = indexPath;
+    
     // Add custom layout
     if (item.layoutMapper != nil) {
         [item.layoutMapper renderToView:cell.contentView];
@@ -1059,9 +1073,7 @@ static const CGFloat kUITableViewRowAnimationDuration = .25f;
     // Init data for cell
     [cell setData:data];
     [item initPropertiesForTarget:cell];
-    [item mapPropertiesToTarget:cell withData:collectionView.data owner:cell context:collectionView];
-    
-    return cell;
+    [item mapPropertiesToTarget:cell withData:context.data owner:cell context:context];
 }
 
 - (UICollectionReusableView *)collectionView:(PBCollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
1.发现在iOS11下使用CollectionView设置estimatedItemSize会导致collectionView代理失效
2.采用placehodercell的方式手动触发计算自动布局高度