### PR TITLE
修正：Plist 中 设置hidden表达式未生效

### DIFF
--- a/Pbind/Classes/Plist/PBRowMapper.m
+++ b/Pbind/Classes/Plist/PBRowMapper.m
@@ -86,6 +86,8 @@ static const CGFloat kHeightUnset = -2;
     
     _pbFlags.dataUnset = [dictionary objectForKey:@"data"] == nil;
     
+    _pbFlags.hiddenExpressive = [_properties isExpressiveForKey:@"hidden"];
+
     if (_clazz == nil) {
         [self initDefaultViewClass];
     }


### PR DESCRIPTION
发现 Plist 中设置的 `hidden` 表达式值没有生效，查到原因是 `PBRowMapper` 没有对标识`hiddenExpressive` 进行初始化绑定。